### PR TITLE
Making class and table names optional

### DIFF
--- a/lib/generators/ruby_llm/install/templates/README.md.tt
+++ b/lib/generators/ruby_llm/install/templates/README.md.tt
@@ -4,9 +4,22 @@ Thanks for installing RubyLLM in your Rails application. Here's what was created
 
 ## Models
 
-- `Chat` - Stores chat sessions and their associated model ID
-- `Message` - Stores individual messages in a chat
-- `ToolCall` - Stores tool calls made by language models
+- `<%= options[:chat_model_name] %>` - Stores chat sessions and their associated model ID
+- `<%= options[:message_model_name] %>` - Stores individual messages in a chat
+- `<%= options[:tool_call_model_name] %>` - Stores tool calls made by language models
+
+## Configuration Options
+
+The generator supports the following options to customize model names:
+
+```bash
+rails generate ruby_llm:install \
+  --chat-model-name=Conversation \
+  --message-model-name=ChatMessage \
+  --tool-call-model-name=FunctionCall
+```
+
+This is useful when you need to avoid namespace collisions with existing models in your application. Table names will be automatically derived from the model names following Rails conventions.
 
 ## Next Steps
 
@@ -28,7 +41,7 @@ Thanks for installing RubyLLM in your Rails application. Here's what was created
 3. **Start using RubyLLM in your code:**
    ```ruby
    # Create a new chat
-   chat = Chat.create!(model_id: "gpt-4o-mini")
+   chat = <%= options[:chat_model_name] %>.create!(model_id: "gpt-4o-mini")
    
    # Ask a question
    response = chat.ask("What's the best Ruby web framework?")

--- a/lib/generators/ruby_llm/install/templates/chat_model.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/chat_model.rb.tt
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
-class Chat < ApplicationRecord
-  acts_as_chat
+class <%= options[:chat_model_name] %> < ApplicationRecord
+  <%= acts_as_chat_declaration %>
 end

--- a/lib/generators/ruby_llm/install/templates/create_chats_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_chats_migration.rb.tt
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
-class CreateChats < ActiveRecord::Migration<%= migration_version %>
+class Create<%= options[:chat_model_name].pluralize %> < ActiveRecord::Migration<%= migration_version %>
   def change
-    create_table :chats do |t|
+    create_table :<%= options[:chat_model_name].tableize %> do |t|
       t.string :model_id
       t.timestamps
     end

--- a/lib/generators/ruby_llm/install/templates/create_messages_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_messages_migration.rb.tt
@@ -1,17 +1,15 @@
-# frozen_string_literal: true
-
-# This migration must be run AFTER create_chats and create_tool_calls migrations
+# This migration must be run AFTER create_<%= options[:chat_model_name].tableize %> and create_<%= options[:tool_call_model_name].tableize %> migrations
 # to ensure proper foreign key references
-class CreateMessages < ActiveRecord::Migration<%= migration_version %>
+class Create<%= options[:message_model_name].pluralize %> < ActiveRecord::Migration<%= migration_version %>
   def change
-    create_table :messages do |t|
-      t.references :chat, null: false, foreign_key: true
+    create_table :<%= options[:message_model_name].tableize %> do |t|
+      t.references :<%= options[:chat_model_name].tableize.singularize %>, null: false, foreign_key: true
       t.string :role
       t.text :content
       t.string :model_id
       t.integer :input_tokens
       t.integer :output_tokens
-      t.references :tool_call, foreign_key: true
+      t.references :<%= options[:tool_call_model_name].tableize.singularize %>
       t.timestamps
     end
   end

--- a/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/create_tool_calls_migration.rb.tt
@@ -1,22 +1,14 @@
-# frozen_string_literal: true
-
-# Migration for creating tool_calls table with database-specific JSON handling
-class CreateToolCalls < ActiveRecord::Migration<%= migration_version %>
+<%#- # Migration for creating tool_calls table with database-specific JSON handling -%>
+class Create<%= options[:tool_call_model_name].pluralize %> < ActiveRecord::Migration<%= migration_version %>
   def change
-    create_table :tool_calls do |t|
+    create_table :<%= options[:tool_call_model_name].tableize %> do |t|
+      t.references :<%= options[:message_model_name].tableize.singularize %>, null: false, foreign_key: true
       t.string :tool_call_id, null: false
       t.string :name, null: false
-      
-      # Use the appropriate JSON column type for the database
-      if postgresql?
-        t.jsonb :arguments, default: {}
-      else
-        t.json :arguments, default: {}
-      end
-      
+      t.<%= postgresql? ? 'jsonb' : 'json' %> :arguments, default: {}
       t.timestamps
     end
 
-    add_index :tool_calls, :tool_call_id
+    add_index :<%= options[:tool_call_model_name].tableize %>, :tool_call_id
   end
 end

--- a/lib/generators/ruby_llm/install/templates/initializer.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/initializer.rb.tt
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # RubyLLM configuration
 RubyLLM.configure do |config|
   # Set your API keys here or use environment variables

--- a/lib/generators/ruby_llm/install/templates/message_model.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/message_model.rb.tt
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
-class Message < ApplicationRecord
-  acts_as_message
+class <%= options[:message_model_name] %> < ApplicationRecord
+  <%= acts_as_message_declaration %>
 end

--- a/lib/generators/ruby_llm/install/templates/tool_call_model.rb.tt
+++ b/lib/generators/ruby_llm/install/templates/tool_call_model.rb.tt
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
-class ToolCall < ApplicationRecord
-  acts_as_tool_call
+class <%= options[:tool_call_model_name] %> < ApplicationRecord
+  <%= acts_as_tool_call_declaration %>
 end

--- a/lib/generators/ruby_llm/install_generator.rb
+++ b/lib/generators/ruby_llm/install_generator.rb
@@ -7,13 +7,21 @@ module RubyLLM
   # Generator for RubyLLM Rails models and migrations
   class InstallGenerator < Rails::Generators::Base
     include Rails::Generators::Migration
+    namespace "ruby_llm:install"
 
     source_root File.expand_path('install/templates', __dir__)
+
+    class_option :chat_model_name, type: :string, default: 'Chat',
+                desc: 'Name of the Chat model class'
+    class_option :message_model_name, type: :string, default: 'Message',
+                desc: 'Name of the Message model class'
+    class_option :tool_call_model_name, type: :string, default: 'ToolCall',
+                desc: 'Name of the ToolCall model class'
 
     desc 'Creates model files for Chat, Message, and ToolCall, and creates migrations for RubyLLM Rails integration'
 
     def self.next_migration_number(dirname)
-      ActiveRecord::Generators::Base.next_migration_number(dirname)
+      ::ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
 
     def migration_version
@@ -26,30 +34,66 @@ module RubyLLM
       false
     end
 
-    def create_migration_files
-      # Create migrations in the correct order with sequential timestamps
-      # to ensure proper foreign key references:
-      # 1. First create chats (no dependencies)
-      # 2. Then create tool_calls (will be referenced by messages)
-      # 3. Finally create messages (depends on both chats and tool_calls)
+    def acts_as_chat_declaration
+      acts_as_chat_params = []
+      if options[:message_model_name]
+        acts_as_chat_params << "message_class: \"#{options[:message_model_name]}\""
+      end
+      if options[:tool_call_model_name]
+        acts_as_chat_params << "tool_call_class: \"#{options[:tool_call_model_name]}\""
+      end
+      if acts_as_chat_params.any?
+        "acts_as_chat #{acts_as_chat_params.join(', ')}"
+      else
+        "acts_as_chat"
+      end
+    end
 
+    def acts_as_message_declaration
+      acts_as_message_params = []
+      if options[:chat_model_name]
+        acts_as_message_params << "chat_class: \"#{options[:chat_model_name]}\""
+      end
+      if options[:tool_call_model_name]
+        acts_as_message_params << "tool_call_class: \"#{options[:tool_call_model_name]}\""
+      end
+      if acts_as_message_params.any?
+        "acts_as_message #{acts_as_message_params.join(', ')}"
+      else
+        "acts_as_message"
+      end
+    end
+
+    def acts_as_tool_call_declaration
+      acts_as_tool_call_params = []
+      if options[:message_model_name]
+        acts_as_tool_call_params << "message_class: \"#{options[:message_model_name]}\""
+      end
+      if acts_as_tool_call_params.any?
+        "acts_as_tool_call #{acts_as_tool_call_params.join(', ')}"
+      else
+        "acts_as_tool_call"
+      end
+    end
+
+    def create_migration_files
       # Use a fixed timestamp for testing and to ensure they're sequential
-      @migration_number = Time.now.utc.strftime('%Y%m%d%H%M%S')
-      migration_template 'create_chats_migration.rb.tt', 'db/migrate/create_chats.rb'
+      # @migration_number = Time.now.utc.strftime('%Y%m%d%H%M%S')
+      migration_template 'create_chats_migration.rb.tt', "db/migrate/create_#{options[:chat_model_name].tableize}.rb"
 
       # Increment timestamp for the next migration
-      @migration_number = (@migration_number.to_i + 1).to_s
-      migration_template 'create_tool_calls_migration.rb.tt', 'db/migrate/create_tool_calls.rb'
+      # @migration_number = (@migration_number.to_i + 1).to_s
+      migration_template 'create_messages_migration.rb.tt', "db/migrate/create_#{options[:message_model_name].tableize}.rb"
 
       # Increment timestamp again for the final migration
-      @migration_number = (@migration_number.to_i + 2).to_s
-      migration_template 'create_messages_migration.rb.tt', 'db/migrate/create_messages.rb'
+      # @migration_number = (@migration_number.to_i + 2).to_s
+      migration_template 'create_tool_calls_migration.rb.tt', "db/migrate/create_#{options[:tool_call_model_name].tableize}.rb"
     end
 
     def create_model_files
-      template 'chat_model.rb.tt', 'app/models/chat.rb'
-      template 'message_model.rb.tt', 'app/models/message.rb'
-      template 'tool_call_model.rb.tt', 'app/models/tool_call.rb'
+      template 'chat_model.rb.tt', "app/models/#{options[:chat_model_name].underscore}.rb"
+      template 'message_model.rb.tt', "app/models/#{options[:message_model_name].underscore}.rb"
+      template 'tool_call_model.rb.tt', "app/models/#{options[:tool_call_model_name].underscore}.rb"
     end
 
     def create_initializer
@@ -57,7 +101,8 @@ module RubyLLM
     end
 
     def show_readme
-      readme 'README.md'
+      content = ERB.new(File.read(source_paths.first + '/README.md.tt')).result(binding)
+      say content
     end
   end
 end

--- a/lib/ruby_llm/active_record/acts_as.rb
+++ b/lib/ruby_llm/active_record/acts_as.rb
@@ -37,7 +37,7 @@ module RubyLLM
           @chat_class = chat_class.to_s
           @tool_call_class = tool_call_class.to_s
 
-          belongs_to :chat, class_name: @chat_class
+          belongs_to :chat, class_name: @chat_class, foreign_key: "#{@chat_class.underscore}_id"
           has_many :tool_calls, class_name: @tool_call_class, dependent: :destroy
 
           belongs_to :parent_tool_call,
@@ -52,7 +52,7 @@ module RubyLLM
         def acts_as_tool_call(message_class: 'Message')
           @message_class = message_class.to_s
 
-          belongs_to :message, class_name: @message_class
+          belongs_to :message, class_name: @message_class, foreign_key: "#{@message_class.underscore}_id"
 
           has_one :result,
                   class_name: @message_class,

--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -34,6 +34,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  # Add generator files
+  spec.files += Dir.glob('lib/generators/**/*')
+
   # Runtime dependencies
   spec.add_dependency 'base64'
   spec.add_dependency 'event_stream_parser', '~> 1'
@@ -41,4 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-multipart', '~> 1'
   spec.add_dependency 'faraday-retry', '~> 2'
   spec.add_dependency 'zeitwerk', '~> 2'
+
+  # Development dependencies
+  spec.add_development_dependency 'rails', '>= 7.0.0'
 end


### PR DESCRIPTION
Added the ability to change the names of the models (and subsequent migrations)

 I did some clean up, as I thought might be best (not knowing your intentions) so would love to know if that was appropriate or not. 
- Removed `frozen_string_literal: true` from templates
- Updated tests to use relative paths
- Updated tests to reflect no need for ordering
- Updated tests to reflect postgres template changes
- Used examples from docs for migrations (removed foreign keys)
- Removed hard coded migration numbers as they get generated automatically by rails and removed dependency issue
- Updated tool migration so that the postgres check happens when rendering the migration
- Updated `acts_as` methods to factor in class names if different than default
- Added `namespace "ruby_llm:install"` in the `install_generator.rb` file so that the the command wouldn't be `ruby_l_l_m:install` and would look like `ruby_llm:install`
- Made README.md a dynamic template to reflect options of class names