### PR TITLE
Addresses comments in PR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   # Rails integration dependencies
   gem 'activerecord', '>= 6.0', '< 9.0'
   gem 'activesupport', '>= 6.0', '< 9.0'
+  gem 'rails', '>= 7.0.0'
 
   # Development dependencies
   gem 'bundler', '>= 2.0'

--- a/lib/generators/ruby_llm/install/templates/README.md.tt
+++ b/lib/generators/ruby_llm/install/templates/README.md.tt
@@ -40,14 +40,21 @@ This is useful when you need to avoid namespace collisions with existing models 
 
 3. **Start using RubyLLM in your code:**
    ```ruby
-   # Create a new chat
+   # In a background job
+   class ChatJob < ApplicationJob
+     def perform(chat_id, question)
+       chat = <%= options[:chat_model_name] %>.find(chat_id)
+       chat.ask(question) do |chunk|
+         Turbo::StreamsChannel.broadcast_append_to(
+           chat, target: "response", partial: "messages/chunk", locals: { chunk: chunk }
+         )
+       end
+     end
+   end
+
+   # Queue the job
    chat = <%= options[:chat_model_name] %>.create!(model_id: "gpt-4o-mini")
-   
-   # Ask a question
-   response = chat.ask("What's the best Ruby web framework?")
-   
-   # Get chat history
-   chat.messages
+   ChatJob.perform_later(chat.id, "What's your favorite Ruby gem?")
    ```
 
 4. **For streaming responses** with ActionCable or Turbo:

--- a/lib/generators/ruby_llm/install_generator.rb
+++ b/lib/generators/ruby_llm/install_generator.rb
@@ -7,16 +7,16 @@ module RubyLLM
   # Generator for RubyLLM Rails models and migrations
   class InstallGenerator < Rails::Generators::Base
     include Rails::Generators::Migration
-    namespace "ruby_llm:install"
+    namespace 'ruby_llm:install'
 
     source_root File.expand_path('install/templates', __dir__)
 
     class_option :chat_model_name, type: :string, default: 'Chat',
-                desc: 'Name of the Chat model class'
+                                   desc: 'Name of the Chat model class'
     class_option :message_model_name, type: :string, default: 'Message',
-                desc: 'Name of the Message model class'
+                                      desc: 'Name of the Message model class'
     class_option :tool_call_model_name, type: :string, default: 'ToolCall',
-                desc: 'Name of the ToolCall model class'
+                                        desc: 'Name of the ToolCall model class'
 
     desc 'Creates model files for Chat, Message, and ToolCall, and creates migrations for RubyLLM Rails integration'
 
@@ -36,58 +36,46 @@ module RubyLLM
 
     def acts_as_chat_declaration
       acts_as_chat_params = []
-      if options[:message_model_name]
-        acts_as_chat_params << "message_class: \"#{options[:message_model_name]}\""
-      end
-      if options[:tool_call_model_name]
-        acts_as_chat_params << "tool_call_class: \"#{options[:tool_call_model_name]}\""
-      end
+      acts_as_chat_params << "message_class: \"#{options[:message_model_name]}\"" if options[:message_model_name]
+      acts_as_chat_params << "tool_call_class: \"#{options[:tool_call_model_name]}\"" if options[:tool_call_model_name]
       if acts_as_chat_params.any?
         "acts_as_chat #{acts_as_chat_params.join(', ')}"
       else
-        "acts_as_chat"
+        'acts_as_chat'
       end
     end
 
     def acts_as_message_declaration
       acts_as_message_params = []
-      if options[:chat_model_name]
-        acts_as_message_params << "chat_class: \"#{options[:chat_model_name]}\""
-      end
+      acts_as_message_params << "chat_class: \"#{options[:chat_model_name]}\"" if options[:chat_model_name]
       if options[:tool_call_model_name]
         acts_as_message_params << "tool_call_class: \"#{options[:tool_call_model_name]}\""
       end
       if acts_as_message_params.any?
         "acts_as_message #{acts_as_message_params.join(', ')}"
       else
-        "acts_as_message"
+        'acts_as_message'
       end
     end
 
     def acts_as_tool_call_declaration
       acts_as_tool_call_params = []
-      if options[:message_model_name]
-        acts_as_tool_call_params << "message_class: \"#{options[:message_model_name]}\""
-      end
+      acts_as_tool_call_params << "message_class: \"#{options[:message_model_name]}\"" if options[:message_model_name]
       if acts_as_tool_call_params.any?
         "acts_as_tool_call #{acts_as_tool_call_params.join(', ')}"
       else
-        "acts_as_tool_call"
+        'acts_as_tool_call'
       end
     end
 
     def create_migration_files
-      # Use a fixed timestamp for testing and to ensure they're sequential
-      # @migration_number = Time.now.utc.strftime('%Y%m%d%H%M%S')
       migration_template 'create_chats_migration.rb.tt', "db/migrate/create_#{options[:chat_model_name].tableize}.rb"
 
-      # Increment timestamp for the next migration
-      # @migration_number = (@migration_number.to_i + 1).to_s
-      migration_template 'create_messages_migration.rb.tt', "db/migrate/create_#{options[:message_model_name].tableize}.rb"
+      migration_template 'create_messages_migration.rb.tt',
+                         "db/migrate/create_#{options[:message_model_name].tableize}.rb"
 
-      # Increment timestamp again for the final migration
-      # @migration_number = (@migration_number.to_i + 2).to_s
-      migration_template 'create_tool_calls_migration.rb.tt', "db/migrate/create_#{options[:tool_call_model_name].tableize}.rb"
+      migration_template 'create_tool_calls_migration.rb.tt',
+                         "db/migrate/create_#{options[:tool_call_model_name].tableize}.rb"
     end
 
     def create_model_files

--- a/ruby_llm.gemspec
+++ b/ruby_llm.gemspec
@@ -29,9 +29,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + ['README.md', 'LICENSE']
   spec.require_paths = ['lib']
 
-  # Add generator files
-  spec.files += Dir.glob('lib/generators/**/*')
-
   # Runtime dependencies
   spec.add_dependency 'base64'
   spec.add_dependency 'event_stream_parser', '~> 1'
@@ -39,7 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-multipart', '~> 1'
   spec.add_dependency 'faraday-retry', '~> 2'
   spec.add_dependency 'zeitwerk', '~> 2'
-
-  # Development dependencies
-  spec.add_development_dependency 'rails', '>= 7.0.0'
 end

--- a/spec/lib/generators/ruby_llm/install_generator_spec.rb
+++ b/spec/lib/generators/ruby_llm/install_generator_spec.rb
@@ -6,8 +6,8 @@ require 'generators/ruby_llm/install_generator'
 
 RSpec.describe RubyLLM::InstallGenerator, type: :generator do
   # Use the actual template directory
-  let(:template_dir) { File.join(File.dirname(__FILE__), '../../../../lib/generators/ruby_llm/install/templates') }
-  let(:generator_file) { File.join(File.dirname(__FILE__), '../../../../lib/generators/ruby_llm/install_generator.rb') }
+  let(:template_dir) { File.join(__dir__, '../../../../lib/generators/ruby_llm/install/templates') }
+  let(:generator_file) { File.join(__dir__, '../../../../lib/generators/ruby_llm/install_generator.rb') }
 
   describe 'migration templates' do
     let(:expected_migration_files) do


### PR DESCRIPTION
Address PR feedback and cleanup

- Replace File.dirname(__FILE__) with __dir__ in specs for better Ruby idioms
- Remove redundant spec.files line for generators (already covered by lib/**/*)
- Move rails development dependency to Gemfile from gemspec
- Update example in README to use ActiveJob instead of controller for better practices

Note on migration timestamps: The current implementation has no table dependencies,
so migration order is not critical. Rails generators automatically handle
timestamps for migrations, making manual timestamp management unnecessary.